### PR TITLE
v1.7.1

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func TestMap(t *testing.T) {
@@ -195,5 +196,56 @@ func TestMap(t *testing.T) {
 		if count != 1 {
 			tt.Errorf("count = %d, expected 1", count)
 		}
+	})
+
+	t.Run("string,time.Time", func(tt *testing.T) {
+		a := NewArena(1024)
+		defer a.Release()
+
+		defer func() {
+			if r := recover(); r == nil {
+				tt.Errorf("expected panic for time.Time value")
+			}
+		}()
+
+		NewMap[string, time.Time](a)
+	})
+
+	t.Run("string,PublicStruct", func(tt *testing.T) {
+		type PublicStruct struct {
+			ID   int
+			Name string
+		}
+		a := NewArena(1024)
+		defer a.Release()
+		m := NewMap[string, PublicStruct](a)
+
+		val := PublicStruct{ID: 1, Name: "test"}
+		key := "p1"
+
+		m.Set(key, val)
+
+		if v, ok := m.Get(key); !ok {
+			tt.Errorf("key %s not found", key)
+		} else if v != val {
+			tt.Errorf("value mismatch: got %v, want %v", v, val)
+		}
+	})
+
+	t.Run("string,PrivateStruct", func(tt *testing.T) {
+		type PrivateStruct struct {
+			id   int
+			name string
+		}
+		a := NewArena(1024)
+		defer a.Release()
+
+		defer func() {
+			if r := recover(); r == nil {
+				tt.Errorf("expected panic for PrivateStruct value")
+			}
+		}()
+
+		NewMap[string, PrivateStruct](a)
 	})
 }

--- a/set_test.go
+++ b/set_test.go
@@ -74,4 +74,42 @@ func TestSet(t *testing.T) {
 			tt.Errorf("test1 is deleted")
 		}
 	})
+
+	t.Run("PublicStruct", func(tt *testing.T) {
+		type PublicStruct struct {
+			ID   int
+			Name string
+		}
+		a := NewArena(1024)
+		defer a.Release()
+		s := NewSet[PublicStruct](a)
+
+		val := PublicStruct{ID: 1, Name: "test"}
+		if ok := s.Add(val); ok {
+			tt.Errorf("val is new key")
+		}
+		if ok := s.Contains(val); ok != true {
+			tt.Errorf("val exists")
+		}
+		if ok := s.Delete(val); ok != true {
+			tt.Errorf("val exists")
+		}
+	})
+
+	t.Run("PrivateStruct", func(tt *testing.T) {
+		type PrivateStruct struct {
+			id   int
+			name string
+		}
+		a := NewArena(1024)
+		defer a.Release()
+
+		defer func() {
+			if r := recover(); r == nil {
+				tt.Errorf("expected panic for PrivateStruct key")
+			}
+		}()
+
+		NewSet[PrivateStruct](a)
+	})
 }

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package armap
 
 const (
 	AppName string = "armap"
-	Version string = "1.7.0"
+	Version string = "1.7.1"
 )


### PR DESCRIPTION
feat: panic on NewMap/NewSet if types are unclonable
    
- Added explicit type checking in NewMap to verify if K and V are clonable via github.com/alecthomas/arena
- Implemented checkType helper to detect panic during clone of zero values
- Updated NewMap to panic immediately if types contain unexported fields (e.g. time.Time, private structs)
- Added test cases for Map and Set covering public structs (success) and private structs/types (panic expectation)